### PR TITLE
feat(rls): register 接口绕过 RLS 校验

### DIFF
--- a/backend/src/main/java/com/kuafuai/dynamic/policy/RlsBypass.java
+++ b/backend/src/main/java/com/kuafuai/dynamic/policy/RlsBypass.java
@@ -1,0 +1,36 @@
+package com.kuafuai.dynamic.policy;
+
+import com.kuafuai.common.login.LoginUser;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.function.Supplier;
+
+/**
+ * 以 RLS 旁路身份执行一段逻辑。
+ *
+ * 用于 register 等"用户身份尚未建立"的写入路径：临时把 SecurityContext.Authentication
+ * 替换为带 bypassRls=true 的 LoginUser（与管理后台同款机制），执行 action，
+ * finally 恢复原 Authentication。
+ */
+public final class RlsBypass {
+
+    private RlsBypass() {
+    }
+
+    public static <T> T runAs(String appId, Supplier<T> action) {
+        SecurityContext ctx = SecurityContextHolder.getContext();
+        Authentication original = ctx.getAuthentication();
+        try {
+            LoginUser anon = new LoginUser(appId, null, null, true);
+            UsernamePasswordAuthenticationToken token =
+                    new UsernamePasswordAuthenticationToken(anon, null, anon.getAuthorities());
+            ctx.setAuthentication(token);
+            return action.get();
+        } finally {
+            ctx.setAuthentication(original);
+        }
+    }
+}

--- a/backend/src/main/java/com/kuafuai/login/controller/LoginController.java
+++ b/backend/src/main/java/com/kuafuai/login/controller/LoginController.java
@@ -11,6 +11,7 @@ import com.kuafuai.common.login.LoginUser;
 import com.kuafuai.common.util.JSON;
 import com.kuafuai.common.util.StringUtils;
 import com.kuafuai.dynamic.service.DynamicService;
+import com.kuafuai.dynamic.policy.RlsBypass;
 import com.kuafuai.login.config.WechatConfig;
 import com.kuafuai.login.entity.LoginVo;
 import com.kuafuai.login.handle.DynamicAuthFilter;
@@ -73,17 +74,20 @@ public class LoginController {
             @RequestParam(value = "table", required = false) String table,
             @RequestBody Map<String, Object> data) {
         String appId = GlobalAppIdFilter.getAppId();
-        if (StringUtils.isEmpty(table)) {
-            table = DynamicAuthFilter.getAppInfo().getAuthTable();
-        }
+        String finalTable = StringUtils.isEmpty(table)
+                ? DynamicAuthFilter.getAppInfo().getAuthTable()
+                : table;
 
-        BaseResponse response = dynamicService.add(appId, table, data);
-        Object id = response.getData();
-        if (id != null) {
-            return ResultUtils.success(loginBusinessService.getUserById(id, appId, table));
-        } else {
-            return response;
-        }
+        // 注册场景：用户身份尚未建立，临时以 bypassRls 身份执行，绕过 RLS WITH CHECK
+        return RlsBypass.runAs(appId, () -> {
+            BaseResponse response = dynamicService.add(appId, finalTable, data);
+            Object id = response.getData();
+            if (id != null) {
+                return ResultUtils.success(loginBusinessService.getUserById(id, appId, finalTable));
+            } else {
+                return response;
+            }
+        });
     }
 
 


### PR DESCRIPTION
注册时用户身份尚未建立，SecurityContext 里没有 LoginUser，导致 RLS WITH CHECK 拒绝 INSERT。新增 RlsBypass.runAs(appId, Supplier) —— 临时把 SecurityContext.Authentication 替换为 bypassRls=true 的 LoginUser（与管理后台同款机制），finally 恢复，避免污染 后续请求。LoginController.register() 整体用该工具包裹。